### PR TITLE
Fixing 'initalize' typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ module "github_terraform_aws_ecs_service" {
 | archived | Specifies if the repository should be archived | `bool` | `false` | no |
 | description | A description of the repository | `string` | n/a | yes |
 | homepage\_url | URL of a page describing the project | `string` | `""` | no |
-| initalize\_repo | Set to true if Terraform will be creating the repo from scratch. | `bool` | `false` | no |
+| initialize\_repo | Set to true if Terraform will be creating the repo from scratch. | `bool` | `false` | no |
 | private | Set to true to create a private repository. Repositories are created as private by default | `bool` | `true` | no |
 | repo\_name | The name of the repository | `string` | n/a | yes |
 | status\_checks\_strict | Require branches to be up to date before merging | `bool` | `true` | no |

--- a/main.tf
+++ b/main.tf
@@ -16,7 +16,7 @@ resource "github_repository" "main" {
   has_projects  = false
   has_wiki      = false
 
-  auto_init = var.initalize_repo
+  auto_init = var.initialize_repo
 }
 
 resource "github_branch_protection" "main" {

--- a/variables.tf
+++ b/variables.tf
@@ -38,7 +38,7 @@ variable "topics" {
   type        = list(string)
 }
 
-variable "initalize_repo" {
+variable "initialize_repo" {
   description = "Set to true if Terraform will be creating the repo from scratch."
   default     = false
   type        = bool


### PR DESCRIPTION
I'm not sure which monster did this, but initialize has *three* i's.