### PR TITLE
Only enable restrictions if additional_master_push_users isn't empty

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   validate:
     docker:
-      - image: trussworks/circleci-docker-primary:e66fbea875bcb788b29b1b5f59142e8231961ec5
+      - image: trussworks/circleci-docker-primary:c542b22c7fb95db0a1bbe043928a457ae6fbeaca
     steps:
       - checkout
       - restore_cache:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: git://github.com/pre-commit/pre-commit-hooks
-    rev: v2.4.0
+    rev: v2.5.0
     hooks:
       - id: check-json
       - id: check-merge-conflict
@@ -12,12 +12,12 @@ repos:
       - id: trailing-whitespace
 
   - repo: git://github.com/igorshubovych/markdownlint-cli
-    rev: v0.19.0
+    rev: v0.23.0
     hooks:
       - id: markdownlint
 
   - repo: git://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.27.0
+    rev: v1.30.0
     hooks:
       - id: terraform_docs
       - id: terraform_fmt

--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ module "github_terraform_aws_ecs_service" {
 ```
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| terraform | >= 0.12 |
+
 ## Providers
 
 | Name | Version |
@@ -35,8 +41,8 @@ module "github_terraform_aws_ecs_service" {
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:-----:|
-| additional\_master\_push\_users | The list of usernames allowed to push to protected master branch. | `list(string)` | n/a | yes |
+|------|-------------|------|---------|:--------:|
+| additional\_master\_push\_users | The list of Github usernames allowed to push to protected master branch | `list(string)` | `[]` | no |
 | archived | Specifies if the repository should be archived | `bool` | `false` | no |
 | description | A description of the repository | `string` | n/a | yes |
 | homepage\_url | URL of a page describing the project | `string` | `""` | no |

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ module "github_terraform_aws_ecs_service" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| additional\_master\_push\_users | The list of Github usernames allowed to push to protected master branch | `list(string)` | `[]` | no |
+| additional\_master\_push\_users | The list of Github usernames allowed to push to the protected master branch | `list(string)` | `[]` | no |
 | archived | Specifies if the repository should be archived | `bool` | `false` | no |
 | description | A description of the repository | `string` | n/a | yes |
 | homepage\_url | URL of a page describing the project | `string` | `""` | no |

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,5 @@
 locals {
-  default_branch      = "master"
-  enable_restrictions = var.additional_master_push_users != ""
+  default_branch = "master"
 }
 
 resource "github_repository" "main" {
@@ -43,9 +42,9 @@ resource "github_branch_protection" "main" {
   }
 
   dynamic "restrictions" {
-    for_each = local.enable_bucket_logging ? [1] : []
+    for_each = var.additional_master_push_users
     content {
-      users = var.additional_master_push_users
+      users = restrictions.value
     }
   }
 

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,6 @@
 locals {
-  default_branch = "master"
+  default_branch      = "master"
+  enable_restrictions = var.additional_master_push_users != ""
 }
 
 resource "github_repository" "main" {
@@ -41,8 +42,11 @@ resource "github_branch_protection" "main" {
     ]
   }
 
-  restrictions {
-    users = var.additional_master_push_users
+  dynamic "restrictions" {
+    for_each = local.enable_bucket_logging ? [1] : []
+    content {
+      users = var.additional_master_push_users
+    }
   }
 
   depends_on = [github_repository.main]

--- a/variables.tf
+++ b/variables.tf
@@ -39,7 +39,7 @@ variable "topics" {
 }
 
 variable "additional_master_push_users" {
-  description = "The list of Github usernames allowed to push to protected master branch"
+  description = "The list of Github usernames allowed to push to the protected master branch"
   default     = []
   type        = list(string)
 }

--- a/variables.tf
+++ b/variables.tf
@@ -39,7 +39,7 @@ variable "topics" {
 }
 
 variable "additional_master_push_users" {
-  description = "The list of usernames allowed to push to protected master branch."
-  default     = null
+  description = "The list of Github usernames allowed to push to protected master branch"
+  default     = []
   type        = list(string)
 }


### PR DESCRIPTION
This will only enable push to master restrictions if `var.additional_master_push_users` isn't empty. Testing this on the ecr-repo results in the following change. 

```hcl
- restrictions {
          - teams = [] -> null
          - users = [] -> null
        }
```