### PR TITLE
Fix issue where additional_master_push_users needs to be a list

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -44,7 +44,7 @@ resource "github_branch_protection" "main" {
   dynamic "restrictions" {
     for_each = var.additional_master_push_users
     content {
-      users = restrictions.value
+      users = [restrictions.value]
     }
   }
 


### PR DESCRIPTION
Somehow Terraform can't do a type check on restrictions.value. It need to be a list otherwise you'll get the following error.

```
Inappropriate value for attribute "users": set of string required.
```