### PR TITLE
Make delete_branch_on_merge default to true, add template option

### DIFF
--- a/.markdownlintrc
+++ b/.markdownlintrc
@@ -3,5 +3,6 @@
   "first-header-h1": false,
   "first-line-h1": false,
   "line_length": false,
-  "no-multiple-blanks": false
+  "no-multiple-blanks": false,
+  "no-inline-html": false
 }

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ module "github_terraform_aws_ecs_service" {
 |------|-------------|------|---------|:--------:|
 | additional\_master\_push\_users | The list of Github usernames allowed to push to the protected master branch | `list(string)` | `[]` | no |
 | archived | Specifies if the repository should be archived | `bool` | `false` | no |
+| delete\_branch\_on\_merge | Delete branches upon merge | `bool` | `true` | no |
 | description | A description of the repository | `string` | n/a | yes |
 | homepage\_url | URL of a page describing the project | `string` | `""` | no |
 | private | Set to true to create a private repository. Repositories are created as private by default | `bool` | `true` | no |

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ module "github_terraform_aws_ecs_service" {
 | private | Set to true to create a private repository. Repositories are created as private by default | `bool` | `true` | no |
 | repo\_name | The name of the repository | `string` | n/a | yes |
 | status\_checks\_strict | Require branches to be up to date before merging | `bool` | `true` | no |
+| template | Optional template to use for creating the repo | <pre>object({<br>    owner      = string<br>    repository = string<br>  })</pre> | `null` | no |
 | topics | The list of topics for the repository | `list(string)` | `[]` | no |
 
 ## Outputs

--- a/main.tf
+++ b/main.tf
@@ -17,6 +17,14 @@ resource "github_repository" "main" {
   has_wiki      = false
 
   delete_branch_on_merge = var.delete_branch_on_merge
+
+  dynamic "template" {
+    for_each = var.template != null ? [var.template] : []
+    content {
+      owner      = template.value.owner
+      repository = template.value.repository
+    }
+  }
 }
 
 resource "github_branch_protection" "main" {

--- a/main.tf
+++ b/main.tf
@@ -15,6 +15,8 @@ resource "github_repository" "main" {
   has_downloads = true
   has_projects  = false
   has_wiki      = false
+
+  delete_branch_on_merge = var.delete_branch_on_merge
 }
 
 resource "github_branch_protection" "main" {

--- a/variables.tf
+++ b/variables.tf
@@ -43,3 +43,9 @@ variable "additional_master_push_users" {
   default     = []
   type        = list(string)
 }
+
+variable "delete_branch_on_merge" {
+  description = "Delete branches upon merge"
+  default     = true
+  type        = bool
+}

--- a/variables.tf
+++ b/variables.tf
@@ -49,3 +49,12 @@ variable "delete_branch_on_merge" {
   default     = true
   type        = bool
 }
+
+variable "template" {
+  description = "Optional template to use for creating the repo"
+  default     = null
+  type = object({
+    owner      = string
+    repository = string
+  })
+}


### PR DESCRIPTION
This change adds two new features:

* adds the ability to toggle `delete_branch_on_merge` (with a default of true)
* adds the ability to add a template to the repo

These are capabilities added for the new Github Terraform provider. I've tested with with plans on our github configuration using the git SHA and can confirm it works as expected.