### PR TITLE
Allow setting repo up as a template

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ module "github_terraform_aws_ecs_service" {
 | delete\_branch\_on\_merge | Delete branches upon merge | `bool` | `true` | no |
 | description | A description of the repository | `string` | n/a | yes |
 | homepage\_url | URL of a page describing the project | `string` | `""` | no |
+| is\_template | Tell GitHub that this is a template repository | `bool` | `false` | no |
 | private | Set to true to create a private repository. Repositories are created as private by default | `bool` | `true` | no |
 | repo\_name | The name of the repository | `string` | n/a | yes |
 | status\_checks\_strict | Require branches to be up to date before merging | `bool` | `true` | no |

--- a/main.tf
+++ b/main.tf
@@ -12,6 +12,8 @@ resource "github_repository" "main" {
   has_projects  = false
   has_wiki      = false
 
+  is_template = var.is_template
+
   default_branch         = var.default_branch_name
   delete_branch_on_merge = var.delete_branch_on_merge
 

--- a/variables.tf
+++ b/variables.tf
@@ -56,6 +56,12 @@ variable "delete_branch_on_merge" {
   type        = bool
 }
 
+variable "is_template" {
+  description = "Tell GitHub that this is a template repository"
+  default     = false
+  type        = bool
+}
+
 variable "template" {
   description = "Optional template to use for creating the repo"
   default     = null


### PR DESCRIPTION
We have some repos that are template repos. Adding this parameter allows us to manage that property. See the terraform docs here:

https://www.terraform.io/docs/providers/github/r/repository.html#is_template

