### PR TITLE
Use github_branch_protection_v3 when upgrading to 4.x.x 

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [github_branch_protection.main](https://registry.terraform.io/providers/hashicorp/github/latest/docs/resources/branch_protection) | resource |
+| [github_branch_protection_v3.main](https://registry.terraform.io/providers/hashicorp/github/latest/docs/resources/branch_protection_v3) | resource |
 | [github_repository.main](https://registry.terraform.io/providers/hashicorp/github/latest/docs/resources/repository) | resource |
 
 ## Inputs

--- a/main.tf
+++ b/main.tf
@@ -26,7 +26,7 @@ resource "github_repository" "main" {
   }
 }
 
-resource "github_branch_protection" "main" {
+resource "github_branch_protection_v3" "main" {
   repository = github_repository.main.name
   branch     = var.default_branch_name
 
@@ -38,6 +38,8 @@ resource "github_branch_protection" "main" {
 
   required_pull_request_reviews {
     dismiss_stale_reviews           = false
+    dismissal_users                 = []
+    dismissal_teams                 = []
     require_code_owner_reviews      = false
     required_approving_review_count = 1
   }
@@ -48,7 +50,7 @@ resource "github_branch_protection" "main" {
     ]
   }
 
-  dynamic "push_restrictions" {
+  dynamic "restrictions" {
     for_each = var.additional_master_push_users
     content {
       users = [restrictions.value]


### PR DESCRIPTION
Switch to using github_branch_protection_v3 to work with the upgrade to 4.x.x