### PR TITLE
Switch back to github_branch_protection

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ No modules.
 
 | Name | Type |
 |------|------|
+| [github_branch.main](https://registry.terraform.io/providers/hashicorp/github/latest/docs/resources/branch) | resource |
+| [github_branch_default.main](https://registry.terraform.io/providers/hashicorp/github/latest/docs/resources/branch_default) | resource |
 | [github_branch_protection_v3.main](https://registry.terraform.io/providers/hashicorp/github/latest/docs/resources/branch_protection_v3) | resource |
 | [github_repository.main](https://registry.terraform.io/providers/hashicorp/github/latest/docs/resources/repository) | resource |
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ No modules.
 |------|------|
 | [github_branch.main](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/branch) | resource |
 | [github_branch_default.main](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/branch_default) | resource |
-| [github_branch_protection_v3.main](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/branch_protection_v3) | resource |
+| [github_branch_protection.main](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/branch_protection) | resource |
 | [github_repository.main](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository) | resource |
 
 ## Inputs

--- a/README.md
+++ b/README.md
@@ -47,10 +47,10 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [github_branch.main](https://registry.terraform.io/providers/hashicorp/github/latest/docs/resources/branch) | resource |
-| [github_branch_default.main](https://registry.terraform.io/providers/hashicorp/github/latest/docs/resources/branch_default) | resource |
-| [github_branch_protection_v3.main](https://registry.terraform.io/providers/hashicorp/github/latest/docs/resources/branch_protection_v3) | resource |
-| [github_repository.main](https://registry.terraform.io/providers/hashicorp/github/latest/docs/resources/repository) | resource |
+| [github_branch.main](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/branch) | resource |
+| [github_branch_default.main](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/branch_default) | resource |
+| [github_branch_protection_v3.main](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/branch_protection_v3) | resource |
+| [github_repository.main](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository) | resource |
 
 ## Inputs
 

--- a/main.tf
+++ b/main.tf
@@ -14,7 +14,6 @@ resource "github_repository" "main" {
 
   is_template = var.is_template
 
-  default_branch         = var.default_branch_name
   delete_branch_on_merge = var.delete_branch_on_merge
 
   dynamic "template" {
@@ -24,6 +23,16 @@ resource "github_repository" "main" {
       repository = template.value.repository
     }
   }
+}
+
+resource "github_branch" "main" {
+  repository = github_repository.main.name
+  branch     = var.default_branch_name
+}
+
+resource "github_branch_default" "main" {
+  repository = github_repository.main.name
+  branch     = github_branch.main.branch
 }
 
 resource "github_branch_protection_v3" "main" {
@@ -57,6 +66,6 @@ resource "github_branch_protection_v3" "main" {
     }
   }
 
-  depends_on = [github_repository.main]
+  depends_on = [github_branch_default.main]
 }
 

--- a/main.tf
+++ b/main.tf
@@ -3,7 +3,7 @@ resource "github_repository" "main" {
   description = var.description
 
   homepage_url = var.homepage_url
-  private      = var.private
+  visibility   = var.private ? "private" : "public"
   archived     = var.archived
   topics       = var.topics
 

--- a/main.tf
+++ b/main.tf
@@ -35,11 +35,12 @@ resource "github_branch_default" "main" {
   branch     = github_branch.main.branch
 }
 
-resource "github_branch_protection_v3" "main" {
-  repository = github_repository.main.name
-  branch     = var.default_branch_name
+resource "github_branch_protection" "main" {
+  repository_id = github_repository.main.node_id
+  pattern       = var.default_branch_name
 
-  enforce_admins = false
+  enforce_admins    = false
+  push_restrictions = var.additional_master_push_users
 
   required_status_checks {
     strict = var.status_checks_strict
@@ -47,8 +48,6 @@ resource "github_branch_protection_v3" "main" {
 
   required_pull_request_reviews {
     dismiss_stale_reviews           = false
-    dismissal_users                 = []
-    dismissal_teams                 = []
     require_code_owner_reviews      = false
     required_approving_review_count = 1
   }
@@ -57,13 +56,6 @@ resource "github_branch_protection_v3" "main" {
     ignore_changes = [
       required_status_checks.0.contexts
     ]
-  }
-
-  dynamic "restrictions" {
-    for_each = var.additional_master_push_users
-    content {
-      users = [restrictions.value]
-    }
   }
 
   depends_on = [github_branch_default.main]

--- a/versions.tf
+++ b/versions.tf
@@ -2,6 +2,9 @@ terraform {
   required_version = ">= 0.13.0"
 
   required_providers {
-    github = ">= 4.10.0"
+    github = {
+      source  = "integrations/github"
+      version = ">= 4.10.0"
+    }
   }
 }


### PR DESCRIPTION
Switches back to the GraphQL endpoint for branch protection and requires the new `integrations/github` provider source